### PR TITLE
Fix the submission page

### DIFF
--- a/books/forms.py
+++ b/books/forms.py
@@ -9,12 +9,25 @@ class BookForm(forms.ModelForm):
     captcha = ReCaptchaField(widget=ReCaptchaV2Checkbox)
 
     def clean_title(self):
+        if self.cleaned_data["title"] == "":
+            raise forms.ValidationError(
+                _("Title is Required. Please ensure Book was selected from dropdown")
+            )
+
         return self.cleaned_data["title"]
 
     def clean_author(self):
+        if self.cleaned_data["author"] == "":
+            raise forms.ValidationError(
+                _("Author is Required. Please ensure Book was selected from dropdown")
+            )
         return self.cleaned_data["author"]
 
     def clean_isbn(self):
+        if self.cleaned_data["isbn"] == "":
+            raise forms.ValidationError(
+                _("ISBN is Required. Please ensure Book was selected from dropdown")
+            )
         return self.cleaned_data["isbn"]
 
     def clean_source(self):
@@ -46,17 +59,6 @@ class BookForm(forms.ModelForm):
             )
 
         return stream_link
-
-    def clean_unique_book(self):
-        cleaned_data = self.cleaned_data
-        found_book = Book.objects.filter(
-            title=cleaned_data["title"], author=cleaned_data["author"]
-        )
-
-        if found_book:
-            raise forms.ValidationError(
-                _("Duplicate Record: This book has already been submitted")
-            )
 
     def clean_atrioc_streamlink(self):
         cleaned_data = self.cleaned_data
@@ -93,7 +95,6 @@ class BookForm(forms.ModelForm):
         cleaned_data = super().clean()
 
         # Call your custom validation methods
-        self.clean_unique_book()
         self.clean_atrioc_streamlink()
         self.clean_chat_username()
 
@@ -117,23 +118,43 @@ class BookForm(forms.ModelForm):
             "submitter": "",
             "stream_link": "",
         }
+        error_messages = {
+            "title": {
+                "required": _(
+                    "Title is Required. Please ensure Book was selected from dropdown"
+                ),
+            },
+            "author": {
+                "required": _(
+                    "Author is Required. Please ensure Book was selected from dropdown"
+                ),
+            },
+            "isbn": {
+                "required": _(
+                    "ISBN is Required. Please ensure Book was selected from dropdown"
+                ),
+            },
+        }
         widgets = {
             "title": forms.HiddenInput(
                 attrs={
                     "class": "form-control form-select invisible",
                     "id": "form-book-title",
+                    "required": True,
                 },
             ),
             "author": forms.HiddenInput(
                 attrs={
                     "class": "form-control form-select invisible",
                     "id": "form-book-author",
+                    "required": True,
                 },
             ),
             "isbn": forms.HiddenInput(
                 attrs={
                     "class": "form-control form-select invisible",
                     "id": "form-book-isbn",
+                    "required": True,
                 },
             ),
             "source": forms.Select(

--- a/books/templates/submissions.html
+++ b/books/templates/submissions.html
@@ -4,8 +4,8 @@
 <div id="content">
     {% if form.errors %}
     {% for field,error in form.errors.items %}
-    <div class="my-2 alert alert-danger" role="alert">
-        Unable to Submit: {{ error|striptags }}
+    <div class="my-2 alert alert-danger text-center" role="alert">
+        Please ensure a book was selected from dropdown under the search to submit.
     </div>
     {% endfor %}
     {%endif%}

--- a/static/js/submission_search.js
+++ b/static/js/submission_search.js
@@ -3,6 +3,10 @@ const dropdownMenu = document.querySelector('#dropdownMenu');
 const titleInput = document.querySelector('#form-book-title');
 const authorInput = document.querySelector('#form-book-author');
 const isbnInput = document.querySelector('#form-book-isbn');
+const submitButton = document.querySelector('button[type="submit"]'); // assuming your submit button has type="submit"
+
+// Disable the submit button initially
+submitButton.disabled = true;
 
 searchBar.addEventListener('keydown', (e) => {
 	if (e.key === 'Enter') {
@@ -59,10 +63,10 @@ searchBar.addEventListener('keydown', (e) => {
 						isbnInput.value = e.target.getAttribute('data-isbn');
 
 						/*
-				    Eventually want to be able to show a preview of the book cover for book selected.
-					However, the current API's that I have been using are very inconsistent with 
-					returning usable image sources.
-					*/
+						Eventually want to be able to show a preview of the book cover for book selected.
+						However, the current API's that I have been using are very inconsistent with 
+						returning usable image sources.
+						*/
 
 						// TODO: Update image source and remove hidden property
 						// const coverImage = document.querySelector('#cover-image img');
@@ -76,9 +80,14 @@ searchBar.addEventListener('keydown', (e) => {
 						// 	e.target.getAttribute('data-title');
 						// document.querySelector('#selected-book-author').textContent =
 						// 	e.target.getAttribute('data-author');
+
+						// Enable the submit button
+						submitButton.disabled = false;
 					});
 					dropdownMenu.appendChild(newOption);
 				});
+				// Show the dropdown after it has been populated
+				$('#dropdownMenuButton').dropdown('show');
 			})
 			.catch((error) => {
 				console.error('Error:', error);

--- a/tests/books/test_forms.py
+++ b/tests/books/test_forms.py
@@ -40,6 +40,39 @@ class TestBooksForm(TestCase):
         form = TestingBookForm(self.book_data)
         self.assertTrue(form.is_valid())
 
+    def test_title_validation(self):
+        # Test with empty title
+        data = self.book_data.copy()
+        data.update({"title": ""})
+        form = TestingBookForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["title"],
+            [_("Title is Required. Please ensure Book was selected from dropdown")],
+        )
+
+    def test_author_validation(self):
+        # Test with empty author
+        data = self.book_data.copy()
+        data.update({"author": ""})
+        form = TestingBookForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["author"],
+            [_("Author is Required. Please ensure Book was selected from dropdown")],
+        )
+
+    def test_isbn_validation(self):
+        # Test with empty isbn
+        data = self.book_data.copy()
+        data.update({"isbn": ""})
+        form = TestingBookForm(data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["isbn"],
+            [_("ISBN is Required. Please ensure Book was selected from dropdown")],
+        )
+
     def test_unique_book_validation(self):
         # Create the first book
         form1 = TestingBookForm(data=self.book_data)
@@ -54,7 +87,6 @@ class TestBooksForm(TestCase):
         self.assertEqual(
             form2.errors["__all__"],
             [
-                _("Duplicate Record: This book has already been submitted"),
                 _("Book with this Title and Author already exists."),
             ],
         )

--- a/tests/books/test_views.py
+++ b/tests/books/test_views.py
@@ -3,7 +3,17 @@ from books.models import Book
 from books.forms import BookForm
 from django.urls import reverse
 from unittest.mock import patch
-from .test_forms import TestingBookForm
+
+# from .test_forms import TestingBookForm
+from django import forms
+
+
+# Create a subclass of BookForm that overrides clean_captcha
+class TestingBookForm(BookForm):
+    captcha = forms.CharField(required=False)
+
+    def clean_captcha(self):
+        return True
 
 
 class RecommendationsViewTest(TestCase):


### PR DESCRIPTION
## Problem

Users were executing the following steps and triggering 500 error:
1. User types in book name
2. User doesnt let the drop down populate
3. User hits submit, without selecting the book from the list
4. User gets Crinky Crongmesed (500 Server Error Page)

This was happenening because the dropdown with the book options was not appearing and users were still allowed to submit a book without using the drop down. This was then throwing an exception on the unique book check that was looking for the title and author.

## Solution

- Check for unique book was redundant, so that was removed
- Replaced with form validations for title, author, and ISBN.
- Updated error messages, and made hidden fields required. Making hidden fields required does not update client side validation, potentially be used in other validations client side
- Updated Submission Page error message to let users know to select book option from dropdown
- Made it so that when dropdown is populated, the dropdown will open automatically.
- Made it so that the submit button is not enabled until the user selects an option from the dropdown.
- Updated the Tests