### PR TITLE
Updating to version 4 of download-artifact

### DIFF
--- a/.github/workflows/main_bigabookclub.yml
+++ b/.github/workflows/main_bigabookclub.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-app
 


### PR DESCRIPTION
Main deployment is failing because the deprecation of [actions/download-artifact@v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), so updated the action to use [actions/download-artifact/v4](https://github.com/actions/download-artifact/tree/v4/).

Will be merging to main to confirm that this works.