### PR TITLE
Nate/fix deployment action

### DIFF
--- a/.github/workflows/main_bigabookclub.yml
+++ b/.github/workflows/main_bigabookclub.yml
@@ -50,7 +50,7 @@ jobs:
         run: zip release.zip ./* -r
 
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: python-app
 

--- a/.github/workflows/main_bigabookclub.yml
+++ b/.github/workflows/main_bigabookclub.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-app
 


### PR DESCRIPTION
Main deployment is failing because the deprecation of [actions/upload-artifact@v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), so updated the action to use [actions/download-artifact/v4](https://github.com/actions/download-artifact/tree/v4/).

Will be merging to main to confirm that this works.